### PR TITLE
Add regex matching for item titles

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -54,7 +54,7 @@ func (a *Aggregator) GetNewTorrentURL() []string {
 
 		if a.url.Matcher.MatchString(item.Title) {
 			log.Println(item.Title + " MATCHED")
-			log.Println(a.url.Regex)
+			log.Println(a.url.Pattern)
 			urls = append(urls, item.Link)
 		} else {
 			log.Println(item.Title + " SKIPPED")

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ const defaultUpdateInterval = 10
 
 type FilteredFeed struct {
 	Host    string
-	Pattern string
+	Pattern string `yaml:"regex"`
 	Matcher *regexp.Regexp
 }
 

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ const defaultUpdateInterval = 10
 
 type FilteredFeed struct {
 	Host    string
-	Regex   string
+	Pattern string
 	Matcher *regexp.Regexp
 }
 
@@ -55,7 +55,7 @@ func NewConfig(filename string) *Config {
 		config.UpdateInterval = defaultUpdateInterval
 	}
 	for num, _ := range config.Feeds {
-		config.Feeds[num].Matcher, err = regexp.Compile(config.Feeds[num].Regex)
+		config.Feeds[num].Matcher, err = regexp.Compile(config.Feeds[num].Pattern)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/config.go
+++ b/config.go
@@ -9,13 +9,20 @@ package main
 import (
 	"io/ioutil"
 	"log"
-)
+	"regexp"
 
-import "github.com/go-yaml/yaml"
+	"github.com/go-yaml/yaml"
+)
 
 const defaultServerHost = "localhost"
 const defaultServerPort = "9091"
 const defaultUpdateInterval = 10
+
+type FilteredFeed struct {
+	Host    string
+	Regex   string
+	Matcher *regexp.Regexp
+}
 
 // Config is handling the config parsing
 type Config struct {
@@ -24,7 +31,7 @@ type Config struct {
 		Port string
 	}
 	UpdateInterval uint64 `yaml:"update_interval"`
-	Feeds          []string
+	Feeds          []FilteredFeed
 }
 
 // NewConfig return a new Config object
@@ -46,6 +53,12 @@ func NewConfig(filename string) *Config {
 	}
 	if config.UpdateInterval == 0 {
 		config.UpdateInterval = defaultUpdateInterval
+	}
+	for num, _ := range config.Feeds {
+		config.Feeds[num].Matcher, err = regexp.Compile(config.Feeds[num].Regex)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	return &config
 }

--- a/main.go
+++ b/main.go
@@ -9,10 +9,10 @@ package main
 import (
 	"fmt"
 	"os"
-)
 
-import "github.com/jessevdk/go-flags"
-import "github.com/jasonlvhit/gocron"
+	"github.com/jasonlvhit/gocron"
+	"github.com/jessevdk/go-flags"
+)
 
 type options struct {
 	Config string `short:"c" long:"conf" description:"Config file" default:"/etc/transmission-rss.conf"`

--- a/transmission-rss.conf
+++ b/transmission-rss.conf
@@ -11,4 +11,5 @@
 # List of feeds to track
 #
 # feeds:
-#     - http://example.com/feed
+#     - host: http://example.com/feed
+#       regex: (foo|bar)


### PR DESCRIPTION
Added support for regex matching item titles. Doing this required changing each feed from a bare URL string to a structure with a host, regex pattern, and regex matcher.